### PR TITLE
Insert codecov and initial pytest support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source=pythonpro
+omit=pythonpro/wsgi.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 3.6
+install:
+  - pip install -r requirements.txt
+  - pip install codecov
+script:
+  - pytest --cov=pythonpro
+after_success:
+  - codecov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=pythonpro.settings
+python_files=test_*.py *_tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+coverage==4.4.1
 Django==2.0b1
+pytest==3.2.3
+pytest-cov==2.5.1
+pytest-django==3.1.2
 pytz==2017.2


### PR DESCRIPTION
This PR seeks to solve the #15, #14 and #12. Questions and feedbacks is welcome 😀

## Main Changes

 - Insertion of `codecov`, `pytest`, `pytest-cov` and `pytest-django`;
 - Creation of `.coveragerc`for define source and omit properties;
 - Creation of `pytest.ini` to define Django settings path and python test files;
 - Creation and definition of some properties for travis, with `.travis.yml`