### PR TITLE
Temporary redirect L7.

### DIFF
--- a/pythonpro/core/views.py
+++ b/pythonpro/core/views.py
@@ -21,7 +21,7 @@ def index(request):
         return redirect(reverse('dashboard:home'))
     # Redirect retorna após campanha L7
     # return redirect('https://pythonpro.com.br')
-    return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v2/?'+
+    return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v2/?' +
                     'utm_source=iscas&utm_medium=trafego-organico&utm_campaign=L7')
 
 

--- a/pythonpro/core/views.py
+++ b/pythonpro/core/views.py
@@ -22,7 +22,7 @@ def index(request):
     # Redirect retorna após campanha L7
     # return redirect('https://pythonpro.com.br')
     return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v1/?'+
-                    'utm_source=home&utm_medium=trafego-organico&utm_campaign=L7')
+                    'utm_source=iscas&utm_medium=trafego-organico&utm_campaign=L7')
 
 
 def thanks(request):

--- a/pythonpro/core/views.py
+++ b/pythonpro/core/views.py
@@ -19,7 +19,10 @@ from pythonpro.domain import user_domain
 def index(request):
     if request.user.is_authenticated:
         return redirect(reverse('dashboard:home'))
-    return redirect('https://pythonpro.com.br')
+    # Redirect retorna após campanha L7
+    # return redirect('https://pythonpro.com.br')
+    return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v1/?'+
+                    'utm_source=home&utm_medium=trafego-organico&utm_campaign=L7')
 
 
 def thanks(request):

--- a/pythonpro/core/views.py
+++ b/pythonpro/core/views.py
@@ -21,7 +21,7 @@ def index(request):
         return redirect(reverse('dashboard:home'))
     # Redirect retorna após campanha L7
     # return redirect('https://pythonpro.com.br')
-    return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v1/?'+
+    return redirect('https://pythonpro.com.br/jornada-rumo-a-primeira-vaga-inscricao-l7-v2/?'+
                     'utm_source=iscas&utm_medium=trafego-organico&utm_campaign=L7')
 
 


### PR DESCRIPTION
Redirecionamento temporário para a nova campanha da Jornada Rumo à Primeira Vaga (L7). Ao final da campanha, o link "antigo" (https://pythonpro.com.br) ficará ativo novamente. 