### PR TITLE
Remove Travis CI and PyUP badges from README #4797

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 Source code of website www.python.pro.br
 
-[![Build Status](https://travis-ci.org/pythonprobr/pythonpro-website.svg?branch=master)](https://travis-ci.org/pythonprobr/pythonpro-website)
+
 [![codecov](https://codecov.io/gh/pythonprobr/pythonpro-website/branch/master/graph/badge.svg)](https://codecov.io/gh/pythonprobr/pythonpro-website)
 [![Code Health](https://landscape.io/github/pythonprobr/pythonpro-website/master/landscape.svg?style=flat)](https://landscape.io/github/pythonprobr/pythonpro-website/master)
-[![Updates](https://pyup.io/repos/github/pythonprobr/pythonpro-website/shield.svg)](https://pyup.io/repos/github/pythonprobr/pythonpro-website/)
-[![Python 3](https://pyup.io/repos/github/pythonprobr/pythonpro-website/python-3-shield.svg)](https://pyup.io/repos/github/pythonprobr/pythonpro-website/)
 
 
 It's developed using Django


### PR DESCRIPTION
Removed badges for unused README, Travis CI, and PyUP.